### PR TITLE
Updated base rstudio image

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -13,7 +13,7 @@
     ],
     "base": {
         "app_type": "rstudio",
-        "docker_image": "harvardat/rstudio-master:1a573c0a",
+        "docker_image": "harvardat/rstudio-master:9cf46609",
         "git_branch": "master",
         "git_dir": "fas-ondemand-rstudio",
         "git_url": "https://github.com/fasrc/fas-ondemand-rstudio.git"

--- a/apps/fas-rstudio-general/form.yml
+++ b/apps/fas-rstudio-general/form.yml
@@ -21,7 +21,7 @@ attributes:
   custom_num_cores: 8
   
   custom_num_gpus: 0 
-  rstudio_version: harvardat_rstudio-master_1a573c0a.sif
+  rstudio_version: harvardat_rstudio-master_9cf46609.sif
   custom_vanillaconf:
     label: "Start rstudio with a new configuration"
     widget: check_box


### PR DESCRIPTION
This PR updates the base rstudio image with general packages requested by an HSPH course. This base image is used directly by the `fas-rstudio-general` app.

Details:
- Docker image: `harvardat/rstudio-master:9cf46609`
- Dockerfile changes:  https://github.com/fasrc/fas-ondemand-rstudio/pull/12
