### PR TITLE
Update fas-rstudio-general image

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -13,7 +13,7 @@
     ],
     "base": {
         "app_type": "rstudio",
-        "docker_image": "harvardat/rstudio-master:9cf46609",
+        "docker_image": "harvardat/rstudio-master:1eaddaaf",
         "git_branch": "master",
         "git_dir": "fas-ondemand-rstudio",
         "git_url": "https://github.com/fasrc/fas-ondemand-rstudio.git"

--- a/apps/fas-rstudio-general/form.yml
+++ b/apps/fas-rstudio-general/form.yml
@@ -21,7 +21,7 @@ attributes:
   custom_num_cores: 8
   
   custom_num_gpus: 0 
-  rstudio_version: harvardat_rstudio-master_9cf46609.sif
+  rstudio_version: harvardat_rstudio-master_1eaddaaf.sif
   custom_vanillaconf:
     label: "Start rstudio with a new configuration"
     widget: check_box


### PR DESCRIPTION
This PR updates the `fas-rstudio-general` form configuration to reference a new image. Make sure to pull and deploy the image before merging.

### Image Details

- Docker hub: [harvardat/rstudio-master:1eaddaaf](https://hub.docker.com/layers/harvardat/rstudio-master/1eaddaaf/images/sha256-2aea2089ade296e5d89997a2c0136e5f008b82954ed555449dc9b4193d0222bd?context=explore)
- Dockerfile: [fasrc/fas-ondemand-rstudio@1eaddaaf](https://github.com/fasrc/fas-ondemand-rstudio/blob/1eaddaaf77814f5581e422c08d94e84bb06355d3/Dockerfile)

### Image Updates

Added the following packages:

- [R.matlab](https://cran.r-project.org/web/packages/R.matlab/)
- [rstan](https://cran.r-project.org/web/packages/rstan/)
- [mcmc](https://cran.r-project.org/web/packages/mcmc/)

@maggiemcfee 