### PR TITLE
Updated general image for Spring 2022

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -13,7 +13,7 @@
     ],
     "base": {
         "app_type": "rstudio",
-        "docker_image": "harvardat/rstudio-master:1eaddaaf",
+        "docker_image": "harvardat/rstudio-master:df3d9266",
         "git_branch": "master",
         "git_dir": "fas-ondemand-rstudio",
         "git_url": "https://github.com/fasrc/fas-ondemand-rstudio.git"

--- a/apps/fas-rstudio-general/form.yml
+++ b/apps/fas-rstudio-general/form.yml
@@ -21,7 +21,7 @@ attributes:
   custom_num_cores: 8
   
   custom_num_gpus: 0 
-  rstudio_version: harvardat_rstudio-master_1eaddaaf.sif
+  rstudio_version: harvardat_rstudio-master_df3d9266.sif
   custom_vanillaconf:
     label: "Start rstudio with a new configuration"
     widget: check_box


### PR DESCRIPTION
This PR updates the docker image for the `fas-rstudio-general` application. It includes a few additional packages requested by STAT 100 for Spring 2022 that may also be useful in general.

- **Docker Image:**  [harvardat/rstudio-master:df3d9266](https://hub.docker.com/layers/harvardat/rstudio-master/df3d9266/images/sha256-846e9f8d0a856deb647a769f06e314b9ae997829f3cc7716f0b8be47f9a4ff7f?context=explore)
- **Dockerfile:** [fasrc/fas-ondemand-rstudio@df3d9266](https://github.com/fasrc/fas-ondemand-rstudio/blob/df3d926626e583cd3e0311a2161914c6180c0772/Dockerfile)
