### PR TITLE
Updated general image for E-PSCI 102 and API-313M 

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -25,7 +25,7 @@
     ],
     "base": {
         "app_type": "rstudio",
-        "docker_image": "harvardat/rstudio-master:df3d9266",
+        "docker_image": "harvardat/rstudio-master:4bbadfad", 
         "git_branch": "master",
         "git_dir": "fas-ondemand-rstudio",
         "git_url": "https://github.com/fasrc/fas-ondemand-rstudio.git"

--- a/apps/fas-rstudio-general/form.yml
+++ b/apps/fas-rstudio-general/form.yml
@@ -20,7 +20,7 @@ attributes:
   custom_num_cores: 8
   
   custom_num_gpus: 0 
-  rstudio_version: harvardat_rstudio-master_df3d9266.sif
+  rstudio_version: harvardat_rstudio-master_4bbadfad.sif
   custom_vanillaconf:
     label: "Start rstudio with a new configuration"
     widget: check_box


### PR DESCRIPTION
NOTE: make sure to merge #12 before this one, as this PR builds upon that one.

---

This PR updates the docker image for the `fas-rstudio-general` application. It includes a few additional packages requested by E-PSCI 102 and API-313M for Spring 2022.

- **Docker Image:**  [harvardat/rstudio-master:4bbadfad](https://hub.docker.com/layers/harvardat/rstudio-master/4bbadfad/images/sha256-3468bebde91d70a67bd4172e9082626df95f9f2dcda81174f9f898f5725b4d2d?context=explore)
- **Dockerfile:** [fasrc/fas-ondemand-rstudio@4bbadfad](https://github.com/fasrc/fas-ondemand-rstudio/blob/4bbadfad1bdc4d967e4b89a3fb8027957e265031/Dockerfile)

For reference, here is the list of installed packages in the R environment:

```
$ docker pull harvardat/rstudio-master:4bbadfad
$ docker run --rm -i harvardat/rstudio-master:4bbadfad R -e 'ip <- as.data.frame(installed.packages()[,c(1,3:4)]);rownames(ip) <- NULL;ip <- ip[is.na(ip$Priority),1:2,drop=FALSE];print(ip, row.names=FALSE)'


R version 4.1.1 (2021-08-10) -- "Kick Things"
Copyright (C) 2021 The R Foundation for Statistical Computing
Platform: x86_64-pc-linux-gnu (64-bit)

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under certain conditions.
Type 'license()' or 'licence()' for distribution details.

R is a collaborative project with many contributors.
Type 'contributors()' for more information and
'citation()' on how to cite R or R packages in publications.

Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

> ip <- as.data.frame(installed.packages()[,c(1,3:4)]);rownames(ip) <- NULL;ip <- ip[is.na(ip$Priority),1:2,drop=FALSE];print(ip, row.names=FALSE)
            Package    Version
              arrow    6.0.0.2
            askpass        1.1
         assertthat      0.2.1
         astrochron        1.1
          backports      1.3.0
          base64enc      0.1-3
                 BH   1.75.0-0
        BiocManager    1.30.16
                bit      4.0.4
              bit64      4.0.5
             bitops      1.0-7
               blob      1.2.2
           blogdown        1.5
           bookdown       0.24
               brew      1.0-6
               brio      1.1.2
              broom      0.7.9
              bslib      0.3.1
             cachem      1.0.6
              callr      3.7.0
              caret     6.0-90
            caTools     1.18.2
         cellranger      1.1.0
          checkmate      2.0.0
           classInt      0.4-3
                cli      3.1.0
              clipr      0.7.1
         colorspace      2.0-2
         commonmark        1.7
         conflicted      1.0.4
           corrplot       0.90
              cpp11      0.4.0
             crayon      1.4.1
        credentials      1.3.1
               curl      4.3.2
         data.table     1.14.2
                DBI      1.1.1
             dbplyr      2.1.1
              Deriv      4.1.3
               desc      1.4.0
           devtools      2.4.2
              dials     0.0.10
         DiceDesign        1.9
            diffobj      0.3.5
             digest     0.6.28
             docopt      0.7.1
         doParallel     1.0.16
          dotCall64      1.0-1
            downlit      0.2.1
              dplyr      1.0.7
             dtplyr      1.1.0
              e1071      1.7-9
 economiccomplexity        1.1
           ellipsis      0.3.2
           evaluate       0.14
              fansi      0.5.0
             farver      2.1.0
            fastmap      1.1.0
             fields       12.5
        fontawesome      0.2.2
            forcats      0.5.1
            foreach      1.5.1
            Formula      1.2-4
      formula.tools      1.7.1
                 fs      1.5.0
                fst      0.9.4
              furrr      0.2.3
             future     1.22.1
       future.apply      1.8.1
             gargle      1.2.0
           generics      0.1.1
               gert      1.4.1
            ggplot2      3.3.5
                 gh      1.3.0
           gitcreds      0.1.1
            globals     0.14.0
               glue      1.4.2
        googledrive      2.0.0
      googlesheets4      1.0.0
              gower      0.2.2
              GPfit      1.0-8
          gridExtra        2.3
             gtable      0.3.0
            hardhat      0.1.6
              haven      2.4.3
              highr        0.9
              Hmisc      4.6-0
                hms      1.1.1
          htmlTable      2.3.0
          htmltools      0.5.2
        htmlwidgets      1.5.4
             httpuv      1.6.3
               httr      1.4.2
            IDPmisc     1.1.20
                ids      1.0.1
             igraph      1.2.7
              infer      1.0.0
                ini      0.3.1
             inline     0.3.19
              ipred     0.9-12
            isoband      0.2.5
          iterators     1.0.13
            janitor      2.1.0
               jpeg      0.1-9
          jquerylib      0.1.4
           jsonlite      1.7.2
              knitr       1.36
           labeling      0.4.2
             Lahman      9.0-0
              later      1.3.0
       latticeExtra     0.6-29
               lava     1.6.10
             learnr     0.10.1
                lhs      1.1.3
          lifecycle      1.0.1
            listenv      0.8.0
            littler     0.3.14
                loo      2.4.1
          lubridate      1.8.0
           magrittr      2.0.1
               maps      3.4.0
           markdown        1.1
         matrixcalc      1.0-5
        matrixStats     0.61.0
               mcmc      0.9-7
            memoise      2.0.0
               mime       0.12
             miniUI    0.1.1.1
          modeldata      0.1.1
       ModelMetrics    1.2.2.2
             modelr      0.1.8
         moderndive      0.5.2
         multitaper     1.0-15
            munsell      0.5.0
          neuralnet     1.44.2
           numDeriv 2016.8-1.1
       nycflights13      1.0.2
            openssl      1.4.5
     operator.tools      1.6.3
            packrat      0.7.0
         parallelly     1.28.1
            parsnip      0.1.7
          patchwork      1.1.1
           pdxTrees      0.4.0
           pheatmap     1.0.12
             pillar      1.6.4
           pkgbuild      1.2.0
          pkgconfig      2.0.3
            pkgload      1.2.3
              plogr      0.2.0
               plyr      1.8.6
                png      0.1-7
             pracma      2.3.3
             praise      1.0.0
        prettyunits      1.1.1
               pROC     1.18.0
           processx      3.5.2
            prodlim 2019.11.13
           progress      1.2.2
          progressr      0.9.0
           promises    1.2.0.1
              proxy     0.4-26
                 ps      1.6.0
              purrr      0.3.4
             quarto        1.0
           R.matlab      3.6.2
        R.methodsS3      1.8.1
               R.oo     1.24.0
            R.utils     2.11.0
                 R6      2.5.1
           rappdirs      0.3.3
             raster      3.5-2
          rbibutils      2.2.4
          rcmdcheck      1.4.0
       RColorBrewer      1.1-2
               Rcpp      1.0.7
          RcppEigen  0.3.3.9.1
       RcppParallel      5.1.4
             Rdpack      2.1.2
              readr      2.0.2
             readxl      1.3.1
            recipes     0.1.17
            redland  1.0.17-14
            rematch      1.0.1
           rematch2      2.1.2
            remotes      2.4.1
               renv     0.14.0
             reprex      2.0.1
            reshape      0.8.8
           reshape2      1.4.4
              rgdal     1.5-27
              rJava      1.0-5
              rlang     0.4.12
           RMariaDB      1.1.2
          rmarkdown       2.11
          rmdshower      2.1.1
           roxygen2      7.1.2
          RPostgres      1.4.1
          rprojroot      2.0.2
            rsample      0.1.0
          rsconnect     0.8.24
            RSQLite      2.2.8
              rstan     2.21.2
         rstudioapi       0.13
            rticles       0.21
          rversions      2.1.1
              rvest      1.0.2
                 s2      1.0.7
               sass      0.4.0
             scales      1.1.1
            selectr      0.4-2
              servr       0.23
        sessioninfo      1.1.1
                 sf      1.0-3
              shiny      1.7.1
             slider      0.2.2
          snakecase     0.11.0
        sourcetools      0.1.7
                 sp      1.4-5
               spam      2.7-0
            SQUAREM     2021.1
        StanHeaders   2.21.0-7
            stringi      1.7.5
            stringr      1.4.0
                sys        3.4
              terra     1.4-11
             testit       0.13
           testthat      3.1.0
             tibble      3.1.5
         tidymodels      0.1.4
              tidyr      1.1.4
         tidyselect      1.1.1
          tidyverse      1.3.1
           timeDate   3043.102
            tinytex       0.34
              tufte       0.10
               tune      0.1.6
               tzdb      0.2.0
              units      0.7-2
            usethis      2.1.3
               utf8      1.2.2
               uuid      1.0-2
                 V8      3.4.2
              vctrs      0.3.8
            viridis      0.6.2
        viridisLite      0.4.0
              vroom      1.5.5
              waldo      0.3.1
               warp      0.2.0
            webshot      0.5.2
            whisker        0.4
             whoami      1.3.0
              withr      2.4.2
                 wk      0.5.0
          workflows      0.2.4
       workflowsets      0.1.0
           xaringan       0.22
               xfun       0.27
               xml2      1.3.2
              xopen      1.0.0
             xtable      1.8-4
               yaml      2.2.1
          yardstick      0.0.8
                zip      2.2.0
> 
```