### PR TITLE
Fix github actions workflow for detecting dockerfile changes

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,9 +3,9 @@ on:
   workflow_dispatch:
     inputs:
       app_name:
-        description: 'Application name (e.g. fas-rstudio-generic)'
+        description: "App Name (e.g. fas-rstudio-general)"
         required: true
-        default: ''
+        default: ""
   repository_dispatch:
     types: [trigger-docker-build]
 
@@ -13,39 +13,32 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - 
-        name: Inspect github event
+      - uses: actions/checkout@v3
+      - name: Inspect github event
         run: |
           echo "Github Event: ${{ toJson(github.event) }}"
-      - 
-        name: Set environment variable for APP_NAME from workflow_dispatch or repository_dispatch
-        run:
+      - name: Set environment variable for APP_NAME from workflow_dispatch or repository_dispatch
+        run: |
           APP_NAME="${{ github.event.inputs.app_name }}";
           if [ -z "$APP_NAME" ]; then
             APP_NAME="${{ github.event.client_payload.app_name }}";
           fi;
           echo "APP_NAME=$APP_NAME" >> $GITHUB_ENV;
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      -
-        name: Login to Dockerhub
-        uses: docker/login-action@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Dockerhub
+        uses: docker/login-action@v2
         with:
-          username:  ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Set environment variables for image tagging
+      - name: Set environment variables for image tagging
         run: |
           echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
-      -
-        name: Build and push
+      - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         if: ${{ env.APP_NAME }}
         with:
           file: "./apps/${{ env.APP_NAME }}/Dockerfile"
@@ -53,6 +46,5 @@ jobs:
           tags: |
             harvardat/${{ env.APP_NAME }}:${{ env.SHORT_SHA }}
             harvardat/${{ env.APP_NAME }}:latest
-      -
-        name: Image digest                  
+      - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-change.yml
+++ b/.github/workflows/docker-change.yml
@@ -12,7 +12,12 @@ jobs:
           fetch-depth: 0 # No shallow clone, we need all history!
       - name: Find Dockerfile that changed
         run: |
-          CHANGED_DOCKERFILES=$(git diff --name-only ${{ github.event.before }}..${{ github.event.after }} | egrep '^apps/[^/]+/Dockerfile$')
+          if [ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]; then
+            CHANGED_DOCKERFILES=$(git diff --name-only ${{ github.event.repository.default_branch }}..${{ github.event.after }} | egrep '^apps/[^/]+/Dockerfile$');
+          else
+            CHANGED_DOCKERFILES=$(git diff --name-only ${{ github.event.before }}..${{ github.event.after }} | egrep '^apps/[^/]+/Dockerfile$');
+          fi;
+          echo "Changed dockerfiles: $CHANGED_DOCKERFILES"
           CHANGED_APP_NAME=$(echo $CHANGED_DOCKERFILES | cut -d '/' -f 2  | sort | head -n 1)
           echo "CHANGED_APP_NAME=$CHANGED_APP_NAME" >> $GITHUB_ENV
       - name: Repository Dispatch


### PR DESCRIPTION
This PR fixes an issue with the github actions workflow for dispatching docker builds when a new branch is pushed. 

**Issue:**
The workflow would [throw an error like this](https://github.com/fasrc/fas-ondemand-jupyter-apps/runs/4929758664?check_suite_focus=true):

```
fatal: Invalid revision range 0000000000000000000000000000000000000000..57405fd2f1b08e37fa7aef2de812db69e249d506
Error: Process completed with exit code 1.
```

**Changes:**
* The key change is to the `.github/workflows/docker-change.yml` workflow, adding a check on the `before` SHA commit. If it's a new branch, then the `before` commit will be zeroed out, so we instead compare the most recent commit on the branch to the default branch in the repository (e.g. `master`). If subsequent commits are pushed, then it will compare the the SHA of the most recent commit on the branch **before** the push to the SHA of the most recent commit on the branch  **after** the push, as before.
* Updated several actions to the latest versions (e.g. `actions/checkout@v2` to `actions/checkout@v3`).

**References:**
* [Github Actions: Webhook Events and Payloads](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push)