### PR TITLE
Updated general form to reduce cores

### DIFF
--- a/apps/fas-rstudio-general/form.yml
+++ b/apps/fas-rstudio-general/form.yml
@@ -14,7 +14,7 @@ attributes:
     label: email address for status notification
     widget: text_field
 
-  custom_memory_per_node: 16
+  custom_memory_per_node: 8
 
 
   custom_num_cores: 2

--- a/apps/fas-rstudio-general/form.yml
+++ b/apps/fas-rstudio-general/form.yml
@@ -8,7 +8,7 @@ attributes:
   bc_queue: "academic"
   custom_time:
     label: "Allocated Time (expressed in MM , or HH:MM:SS , or DD-HH:MM)."
-    value: "04:00:00"
+    value: "02:00:00"
     widget: text_field
   custom_email_address:
     label: email address for status notification

--- a/apps/fas-rstudio-general/form.yml
+++ b/apps/fas-rstudio-general/form.yml
@@ -13,22 +13,22 @@ attributes:
   custom_email_address:
     label: email address for status notification
     widget: text_field
-  
+
   custom_memory_per_node: 16
-  
-  
-  custom_num_cores: 8
-  
-  custom_num_gpus: 0 
+
+
+  custom_num_cores: 2
+
+  custom_num_gpus: 0
   rstudio_version: harvardat_fas-rstudio-general_sha-7b5663a.sif
   custom_vanillaconf:
     label: "Start rstudio with a new configuration"
     widget: check_box
     value: 1
     help: |
-          **_Checking this box will start rstudio with a fresh configuration._** 
-          
-          This is useful if you need to run different instances at the same time with different configurations.<br> 
+          **_Checking this box will start rstudio with a fresh configuration._**
+
+          This is useful if you need to run different instances at the same time with different configurations.<br>
           Leave the box unchecked if you want rstudio to start with the default configuration you have in your ~/.rstudio
 
 form:


### PR DESCRIPTION
This PR reduces the number of cores from 8 to 2 and memory from 16gb to 8gb since the overall academic cluster is running out of cores for the number of students using it this semester. Each 4gb of memory requested effectively uses 1 core, so we need to adjust memory and cores in tandem. It also reduces the default time allocated to the job from 4hrs to 2hrs. Students can adjust this higher if needed, but this should ensure inactive jobs clear out quicker by default.

Rstudio Server should be able to run OK on just 2 cores. If more cores are needed, we can either create an app specific to the course with their compute requirements (justified), or expose the CPU selection form to users with reduced defaults.

Here's what it would look like to expose the CPU and Memory selection on the `form.yml`:

```yaml
  custom_memory_per_node:
    label: Memory Allocation in GB
    value: 8
    min: 8
    max: 16
    step: 4
    widget: number_field

  custom_num_cores:
    label: Number of cores
    value: 2
    min: 2
    max: 4
    step: 2
    widget: number_field
```

That would allow the user to select from 8-16 GB memory in increments of 4 and 2-4 CPU cores.

@raminderj 


